### PR TITLE
Removed #6377 from release notes

### DIFF
--- a/docs/releasenotes/9.2.0.rst
+++ b/docs/releasenotes/9.2.0.rst
@@ -76,9 +76,7 @@ TODO
 Other Changes
 =============
 
-Fixed bug with rounding pixels to palette
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+TODO
+^^^^
 
-Fixed a bug when rounding image pixels to palette colors. This affects the results of
-``Image.quantize`` and of ``Image.convert`` when converting from mode "RGB" to "P",
-"L", or "1", regardless of whether dithering is enabled.
+TODO


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6377

Not every change to Pillow makes it into the release notes. Most just live in the [changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst) and in the [GitHub release description](https://github.com/python-pillow/Pillow/releases/tag/9.1.0).

Feel free to push back on this if you want, but I'm not convinced your change needs to be in the release notes?